### PR TITLE
Long length fix

### DIFF
--- a/mc3p/parsing.py
+++ b/mc3p/parsing.py
@@ -80,10 +80,10 @@ def emit_int(i):
 MC_int = Parsem(parse_int, emit_int)
 
 def parse_long(stream):
-    return struct.unpack_from(">l",stream.read(8))[0]
+    return struct.unpack_from(">q",stream.read(8))[0]
 
 def emit_long(l):
-    return struct.pack(">l",l)
+    return struct.pack(">q",l)
 
 MC_long = Parsem(parse_long, emit_long)
 


### PR DESCRIPTION
Long datatype fix, http://wiki.vg/Protocol says it's 8 bytes and 'l' only reads 4 (http://docs.python.org/library/struct.html)
