### PR TITLE
Added a log plugin

### DIFF
--- a/mc3p/parsing.py
+++ b/mc3p/parsing.py
@@ -22,7 +22,8 @@ logger = logging.getLogger('parsing')
 class Parsem(object):
     """Parser/emitter."""
 
-    def __init__(self,parser,emitter):
+    def __init__(self,parser,emitter, name=None):
+        self.name = name
         setattr(self,'parse',parser)
         setattr(self,'emit',emitter)
 
@@ -53,7 +54,7 @@ def defmsg(msgtype, name, pairs):
     def emit(msg):
         return ''.join([emit_unsigned_byte(msgtype),
                         ''.join([parsem.emit(msg[name]) for (name,parsem) in pairs])])
-    return Parsem(parse,emit)
+    return Parsem(parse,emit,name)
 
 def defloginmsg(tuples):
     """One-off used to define login message.

--- a/mc3p/plugin/log.py
+++ b/mc3p/plugin/log.py
@@ -1,0 +1,57 @@
+# This source file is part of mc3p, the Minecraft Protocol Parsing Proxy.
+#
+# Copyright (C) 2011 Matthew J. McGill
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License v2 as published by
+# the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+
+from mc3p.plugins import MC3Plugin, msghdlr
+from mc3p.messages import cli_msgs, srv_msgs
+
+IGNORE = ['mgstype']
+SHORTEN = ['chunk', 'raw_bytes']
+
+class MutePlugin(MC3Plugin):
+    def default_handler(self, msg, source):
+        line = []
+        msgs = srv_msgs # TODO
+        if source == 'server':
+            line.append('Server -> Client')
+            msgs = srv_msgs
+        elif source == 'client':
+            line.append('Client -> Server')
+            msgs = cli_msgs
+        else:
+            line.append('[%s]' % source)
+        try:
+            parsem = msgs[msg['msgtype']]
+        except ValueError:
+            parsem = None
+        name = None
+        if parsem is not None:
+            name = parsem.name
+        if name is None:
+            name = 'Unknown'
+        line.append('0x%.2x (%s)' % (msg['msgtype'], name))
+        line.append('%d bytes' % len(msg['raw_bytes']))
+        print ' '.join(line)
+        for key, value in msg.iteritems():
+            if key not in IGNORE:
+                if key in SHORTEN:
+                    print '    %s: ...' % key
+                else:
+                    print '    %s: %r' % (key, value)
+        print
+        return True
+


### PR DESCRIPTION
Hey there!

I needed to look at the communication between mineserver and the minecraft client and since mc3p got recommended to me and it seemed to be pretty nice, I did a quick and dirty mc3p plugin that just prints all messages to stdout. I found it pretty useful (it required a little change to the mc3p core code though) and thought it might also be helpful for other people, so I'm doing this pull request =)

Example output:

```

Server -> Client 0x23 (Entity head look) 6 bytes
    raw_bytes: ...
    msgtype: 35
    eid: 4
    head_yaw: 36

Client -> Server 0x0a (Player state) 2 bytes
    raw_bytes: ...
    msgtype: 10
    on_ground: True

Client -> Server 0x0a (Player state) 2 bytes
    raw_bytes: ...
    msgtype: 10
    on_ground: True

Client -> Server 0x0a (Player state) 2 bytes
    raw_bytes: ...
    msgtype: 10
    on_ground: True
```
